### PR TITLE
feat(card): support custom image render function

### DIFF
--- a/src/components/Card/CardImage.jsx
+++ b/src/components/Card/CardImage.jsx
@@ -1,19 +1,29 @@
 import React from 'react'
-import { number, object, oneOfType, string } from 'prop-types'
+import { func, number, object, oneOfType, string } from 'prop-types'
 import Image from '../Image'
 import ResponsiveMedia from '../ResponsiveMedia'
 
-const CardImage = ({ src, ratio, theme, ...rest }) => {
+const renderImage = ({ render, src, ...rest }) => {
+  if (render) return render()
   if (!src) return null
+
+  return <Image src={src} {...rest} />
+}
+
+const CardImage = ({ ratio, theme, ...rest }) => {
+  const image = renderImage({ ...rest })
+
+  if (!image) return null
 
   return (
     <ResponsiveMedia ratio={ratio} className={theme?.image}>
-      <Image src={src} {...rest} />
+      {image}
     </ResponsiveMedia>
   )
 }
 
 CardImage.propTypes = {
+  render: func,
   src: string,
   alt: string,
   ratio: oneOfType([number, string]),

--- a/src/components/Card/CardImage.spec.jsx
+++ b/src/components/Card/CardImage.spec.jsx
@@ -20,4 +20,18 @@ describe('Components/CardImage', () => {
       'https://example.com/image.png'
     )
   })
+
+  it("should render correctly when 'render' is set", () => {
+    const wrapper = shallow(
+      <CardImage
+        render={() => <img src="https://example.com/image.jpg" alt="" />}
+      />
+    )
+
+    expect(wrapper.type()).toEqual(ResponsiveMedia)
+    expect(wrapper.prop('className')).toEqual(undefined)
+    expect(wrapper.find('img').prop('src')).toEqual(
+      'https://example.com/image.jpg'
+    )
+  })
 })


### PR DESCRIPTION
Support replacing the out-of-the renderer for `<CardImage />` with a custom function